### PR TITLE
chunked: Add AppendFile and PartialReadFile syscalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased][]
 
 - Add `ManageExtension`: Factory reset the entire device or the state of a given client ([#11][])
-- `ChunkedExtension`: Add `PartialReadFile` syscall.
+- `ChunkedExtension`: Add `AppendFile` and `PartialReadFile` syscalls.
 
 [#11]: https://github.com/trussed-dev/trussed-staging/pull/11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased][]
 
 - Add `ManageExtension`: Factory reset the entire device or the state of a given client ([#11][])
+- `ChunkedExtension`: Add `PartialReadFile` syscall.
 
 [#11]: https://github.com/trussed-dev/trussed-staging/pull/11
 


### PR DESCRIPTION
This PR adds two syscalls to the `ChunkedExtension`:
- `AppendFile` appends data to an existing file.
- `PartialReadFile` reads a file from an offset.

These syscalls are lightweight alternatives to the chunked syscalls that can be used if the application protocol already implements a chunking mechanism.