### PR TITLE
Remove encrypted-chunked feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,7 @@ trussed = { workspace = true, features = ["virt"] }
 default = ["manage"]
 
 wrap-key-to-file = ["chacha20poly1305", "trussed-wrap-key-to-file"]
-chunked = ["trussed-chunked"]
-encrypted-chunked = ["chunked", "chacha20poly1305/stream", "trussed-chunked/encrypted-chunked"]
+chunked = ["trussed-chunked", "chacha20poly1305/stream"]
 manage = ["trussed-manage"]
 
 virt = ["std", "trussed/virt"]

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 check:
 	RUSTLFAGS='-Dwarnings' cargo check --all-features --all-targets --workspace
 	RUSTLFAGS='-Dwarnings' cargo check --no-default-features
-	RUSTLFAGS='-Dwarnings' cargo check --features encrypted-chunked
+	RUSTLFAGS='-Dwarnings' cargo check --features chunked
 	RUSTLFAGS='-Dwarnings' cargo check --features manage
 	RUSTLFAGS='-Dwarnings' cargo check --features wrap-key-to-file
 

--- a/extensions/chunked/Cargo.toml
+++ b/extensions/chunked/Cargo.toml
@@ -13,6 +13,3 @@ license.workspace = true
 serde.workspace = true
 serde-byte-array.workspace = true
 trussed.workspace = true
-
-[features]
-encrypted-chunked = []

--- a/extensions/chunked/src/lib.rs
+++ b/extensions/chunked/src/lib.rs
@@ -5,7 +5,6 @@
 #![warn(non_ascii_idents, trivial_casts, unused, unused_qualifications)]
 #![deny(unsafe_code)]
 
-#[cfg(feature = "encrypted-chunked")]
 pub mod utils;
 
 use serde::{Deserialize, Serialize};
@@ -30,10 +29,8 @@ impl Extension for ChunkedExtension {
 #[allow(missing_docs, clippy::large_enum_variant)]
 pub enum ChunkedRequest {
     StartChunkedWrite(request::StartChunkedWrite),
-    #[cfg(feature = "encrypted-chunked")]
     StartEncryptedChunkedWrite(request::StartEncryptedChunkedWrite),
     StartChunkedRead(request::StartChunkedRead),
-    #[cfg(feature = "encrypted-chunked")]
     StartEncryptedChunkedRead(request::StartEncryptedChunkedRead),
     ReadChunk(request::ReadChunk),
     WriteChunk(request::WriteChunk),
@@ -47,10 +44,8 @@ pub enum ChunkedRequest {
 pub enum ChunkedReply {
     ReadChunk(reply::ReadChunk),
     StartChunkedWrite(reply::StartChunkedWrite),
-    #[cfg(feature = "encrypted-chunked")]
     StartEncryptedChunkedWrite(reply::StartEncryptedChunkedWrite),
     StartChunkedRead(reply::StartChunkedRead),
-    #[cfg(feature = "encrypted-chunked")]
     StartEncryptedChunkedRead(reply::StartEncryptedChunkedRead),
     WriteChunk(reply::WriteChunk),
     AbortChunkedWrite(reply::AbortChunkedWrite),
@@ -107,7 +102,6 @@ pub mod request {
         }
     }
 
-    #[cfg(feature = "encrypted-chunked")]
     #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
     pub struct StartEncryptedChunkedWrite {
         pub location: Location,
@@ -117,7 +111,6 @@ pub mod request {
         pub nonce: Option<ByteArray<CHACHA8_STREAM_NONCE_LEN>>,
     }
 
-    #[cfg(feature = "encrypted-chunked")]
     impl TryFrom<ChunkedRequest> for StartEncryptedChunkedWrite {
         type Error = Error;
         fn try_from(request: ChunkedRequest) -> Result<Self, Self::Error> {
@@ -128,7 +121,6 @@ pub mod request {
         }
     }
 
-    #[cfg(feature = "encrypted-chunked")]
     impl From<StartEncryptedChunkedWrite> for ChunkedRequest {
         fn from(request: StartEncryptedChunkedWrite) -> Self {
             Self::StartEncryptedChunkedWrite(request)
@@ -157,7 +149,6 @@ pub mod request {
         }
     }
 
-    #[cfg(feature = "encrypted-chunked")]
     #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
     pub struct StartEncryptedChunkedRead {
         pub location: Location,
@@ -165,7 +156,6 @@ pub mod request {
         pub key: KeyId,
     }
 
-    #[cfg(feature = "encrypted-chunked")]
     impl TryFrom<ChunkedRequest> for StartEncryptedChunkedRead {
         type Error = Error;
         fn try_from(request: ChunkedRequest) -> Result<Self, Self::Error> {
@@ -176,7 +166,6 @@ pub mod request {
         }
     }
 
-    #[cfg(feature = "encrypted-chunked")]
     impl From<StartEncryptedChunkedRead> for ChunkedRequest {
         fn from(request: StartEncryptedChunkedRead) -> Self {
             Self::StartEncryptedChunkedRead(request)
@@ -318,11 +307,9 @@ pub mod reply {
         }
     }
 
-    #[cfg(feature = "encrypted-chunked")]
     #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
     pub struct StartEncryptedChunkedWrite {}
 
-    #[cfg(feature = "encrypted-chunked")]
     impl TryFrom<ChunkedReply> for StartEncryptedChunkedWrite {
         type Error = Error;
         fn try_from(reply: ChunkedReply) -> Result<Self, Self::Error> {
@@ -333,7 +320,6 @@ pub mod reply {
         }
     }
 
-    #[cfg(feature = "encrypted-chunked")]
     impl From<StartEncryptedChunkedWrite> for ChunkedReply {
         fn from(reply: StartEncryptedChunkedWrite) -> Self {
             Self::StartEncryptedChunkedWrite(reply)
@@ -362,11 +348,9 @@ pub mod reply {
         }
     }
 
-    #[cfg(feature = "encrypted-chunked")]
     #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
     pub struct StartEncryptedChunkedRead {}
 
-    #[cfg(feature = "encrypted-chunked")]
     impl TryFrom<ChunkedReply> for StartEncryptedChunkedRead {
         type Error = Error;
         fn try_from(reply: ChunkedReply) -> Result<Self, Self::Error> {
@@ -377,7 +361,6 @@ pub mod reply {
         }
     }
 
-    #[cfg(feature = "encrypted-chunked")]
     impl From<StartEncryptedChunkedRead> for ChunkedReply {
         fn from(reply: StartEncryptedChunkedRead) -> Self {
             Self::StartEncryptedChunkedRead(reply)
@@ -492,7 +475,6 @@ pub trait ChunkedClient: ExtensionClient<ChunkedExtension> + FilesystemClient {
     ///
     /// More chunks can be written with [`write_file_chunk`](ChunkedClient::write_file_chunk).
     /// The data is flushed and becomes readable when a chunk smaller than the maximum capacity of a [`Message`] is transfered.
-    #[cfg(feature = "encrypted-chunked")]
     fn start_encrypted_chunked_write(
         &mut self,
         location: Location,
@@ -527,7 +509,6 @@ pub trait ChunkedClient: ExtensionClient<ChunkedExtension> + FilesystemClient {
     /// More chunks can be read with [`read_file_chunk`](ChunkedClient::read_file_chunk).
     /// The read is over once a chunk of size smaller than the maximum capacity of a [`Message`] is transfered.
     /// Only once the entire file has been read does the data have been properly authenticated.
-    #[cfg(feature = "encrypted-chunked")]
     fn start_encrypted_chunked_read(
         &mut self,
         location: Location,

--- a/tests/encrypted-chunked.rs
+++ b/tests/encrypted-chunked.rs
@@ -1,7 +1,7 @@
 // Copyright (C) Nitrokey GmbH
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-#![cfg(all(feature = "virt", feature = "encrypted-chunked"))]
+#![cfg(all(feature = "virt", feature = "chunked"))]
 
 use littlefs2::path::PathBuf;
 use serde_byte_array::ByteArray;


### PR DESCRIPTION
This patch always enables the syscalls that previously were behind the encrypted-chunked feature.  This makes sure that enabling the feature in one crate does not break another crate that also depends on trussed-chunked.  In practice, the feature is always enabled anyway so separating the encrypted syscalls does not bring any benefits.

Fixes: https://github.com/trussed-dev/trussed-staging/issues/20

---

Changelog will be updated in the release PR.