### PR TITLE
Release trussed-staging and extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
+-
+
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/v0.2.0...HEAD
+
+## [0.2.0][] - 2024-03-15
+
+[0.2.0]: https://github.com/trussed-dev/trussed-staging/compare/v0.1.0...v0.2.0
+
+- Move extension definitions into separate crates (see the `extensions` directory, [#3][])
 - Add `ManageExtension`: Factory reset the entire device or the state of a given client ([#11][])
 - `ChunkedExtension`: Add `AppendFile` and `PartialReadFile` syscalls.
+- Remove the `encrypted-chunked` feature and always enable encrypted syscalls
+  for `ChunkedExtension` ([#20][])
 
+[#3]: https://github.com/trussed-dev/trussed-staging/issues/3
 [#11]: https://github.com/trussed-dev/trussed-staging/pull/11
-
-[Unreleased]: https://github.com/Nitrokey/trussed-staging/compare/v0.1.0...HEAD
+[#20]: https://github.com/trussed-dev/trussed-staging/issues/20
 
 ## [0.1.0][] - 2023-04-26
 
@@ -24,4 +35,4 @@ Initial release with these extensions:
 - `ChunkedExtension`: read or write an unencrypted or encrypted file that is larger than the default Trussed message size in chunks
 - `WrapKeyToFileExtension`: wrap or unwrap a key to or from a file
 
-[0.1.0]: https://github.com/Nitrokey/trussed-staging/releases/tag/v0.1.0
+[0.1.0]: https://github.com/trussed-dev/trussed-staging/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ trussed = { version = "0.1.0", features = ["serde-extensions"] }
 
 [package]
 name = "trussed-staging"
-version = "0.1.0"
+version = "0.2.0"
 description = "Work in progress trussed features"
 authors.workspace = true
 edition.workspace = true

--- a/extensions/chunked/CHANGELOG.md
+++ b/extensions/chunked/CHANGELOG.md
@@ -1,0 +1,27 @@
+<!--
+Copyright (C) Nitrokey GmbH
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased][]
+
+-
+
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/chunked-v0.1.0...HEAD
+
+## [0.1.0][] - 2024-03-15
+
+- Extract the `ChunkedExtension` from `trussed-staging` 0.1.0 ([#3][])
+- Add `AppendFile` and `PartialReadFile` syscalls
+- Remove the `encrypted-chunked` feature and always enable encrypted syscalls ([#20][])
+
+[#3]: https://github.com/trussed-dev/trussed-staging/issues/3
+[#20]: https://github.com/trussed-dev/trussed-staging/issues/20
+
+[0.1.0]: https://github.com/trussed-dev/trussed-staging/releases/tag/chunked-v0.1.0

--- a/extensions/manage/CHANGELOG.md
+++ b/extensions/manage/CHANGELOG.md
@@ -1,0 +1,26 @@
+<!--
+Copyright (C) Nitrokey GmbH
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased][]
+
+-
+
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/manage-v0.1.0...HEAD
+
+## [0.1.0][] - 2024-03-15
+
+Initial release of the `ManageExtension` that allows the factory reset of the
+entire device or of the state of a given client ([#11][]).
+
+[#11]: https://github.com/trussed-dev/trussed-staging/pull/11
+
+[0.1.0]: https://github.com/trussed-dev/trussed-staging/releases/tag/manage-v0.1.0
+

--- a/extensions/wrap-key-to-file/CHANGELOG.md
+++ b/extensions/wrap-key-to-file/CHANGELOG.md
@@ -1,0 +1,25 @@
+<!--
+Copyright (C) Nitrokey GmbH
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased][]
+
+-
+
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/wrap-key-to-file-v0.1.0...HEAD
+
+## [0.1.0][] - 2024-03-15
+
+- Extract the `WrapKeyToFileExtension` from `trussed-staging` 0.1.0 ([#3][])
+
+[#3]: https://github.com/trussed-dev/trussed-staging/issues/3
+
+[0.1.0]: https://github.com/trussed-dev/trussed-staging/releases/tag/wrap-key-to-file-v0.1.0
+


### PR DESCRIPTION
This patch releases v0.2.0 of the trussed-staging backend and v0.1.0 of the new extension crates trussed-chunked, trussed-manage and trussed-wrap-key-to-file.