### PR TITLE
Remove manage from default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
--
+- Remove `manage` from default features.
 
 [Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/v0.2.0...HEAD
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ trussed-wrap-key-to-file = { version = "0.1.0", optional = true }
 trussed = { workspace = true, features = ["virt"] }
 
 [features]
-default = ["manage"]
+default = []
 
 wrap-key-to-file = ["chacha20poly1305", "trussed-wrap-key-to-file"]
 chunked = ["trussed-chunked", "chacha20poly1305/stream"]


### PR DESCRIPTION
For some reason, the manage extension is implemented by default by the trussed-staging backend while the chunked and wrap-key-to-file extensions have to be specified explicitly.  For consistency and to avoid activating features we don’t need, this patch removes the manage feature from the default features.