### PR TITLE
Release extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/v0.3.2...HEAD
 
--
+- Update extensions:
+  - `trussed-chunked` v0.2.0
+  - `trussed-hkdf` v0.3.0
+  - `trussed-hpke` v0.2.0
+  - `trussed-manage` v0.2.0
+  - `trussed-wrap-key-to-file` v0.2.0
+  - `trussed-fs-info` v0.2.0
 
 ## [0.3.2][] - 2024-10-18
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "Apache-2.0 OR MIT"
 littlefs2-core = "0.1"
 serde = { version = "1.0.160", default-features = false, features = ["derive"] }
 serde-byte-array = "0.1.2"
-trussed-core = { version = "0.1.0-rc.1", features = ["serde-extensions"] }
+trussed-core = { version = "0.1.0", features = ["serde-extensions"] }
 
 [package]
 name = "trussed-staging"
@@ -48,12 +48,12 @@ digest = { version = "0.10.7", default-features = false }
 hex-literal = { version = "0.4.0", optional = true }
 aead = { version = "0.5.2", optional = true, default-features = false }
 
-trussed-chunked = { version = "0.1.0", optional = true }
-trussed-hkdf = { version = "0.2.0", optional = true }
-trussed-hpke = { version = "0.1.0", optional = true }
-trussed-manage = { version = "0.1.0", optional = true }
-trussed-wrap-key-to-file = { version = "0.1.0", optional = true }
-trussed-fs-info = { version = "0.1.0", optional = true } 
+trussed-chunked = { version = "0.2.0", optional = true }
+trussed-hkdf = { version = "0.3.0", optional = true }
+trussed-hpke = { version = "0.2.0", optional = true }
+trussed-manage = { version = "0.2.0", optional = true }
+trussed-wrap-key-to-file = { version = "0.2.0", optional = true }
+trussed-fs-info = { version = "0.2.0", optional = true } 
 
 [dev-dependencies]
 hex-literal = "0.4.0"

--- a/extensions/chunked/CHANGELOG.md
+++ b/extensions/chunked/CHANGELOG.md
@@ -11,9 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/chunked-v0.2.0...HEAD
+
 -
 
-[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/chunked-v0.1.0...HEAD
+## [0.2.0][] - 2025-01-08
+
+[0.2.0]: https://github.com/trussed-dev/trussed-staging/releases/tag/chunked-v0.2.0
+
+- Replace `trussed` dependency with `trussed-core`.
 
 ## [0.1.0][] - 2024-03-15
 

--- a/extensions/chunked/Cargo.toml
+++ b/extensions/chunked/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "trussed-chunked"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/extensions/fs-info/CHANGELOG.md
+++ b/extensions/fs-info/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/fs-info-v0.1.0...HEAD
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/fs-info-v0.2.0...HEAD
+
+-
+
+## [0.2.0][] - 2025-01-08
+
+[0.2.0]: https://github.com/Nitrokey/trussed-staging/releases/tag/fs-info-v0.2.0
 
 - Replace `trussed` dependency with `trussed-core`.
 

--- a/extensions/fs-info/Cargo.toml
+++ b/extensions/fs-info/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "trussed-fs-info"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/extensions/hkdf/CHANGELOG.md
+++ b/extensions/hkdf/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/hkdf-v0.2.0...HEAD
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/hkdf-v0.3.0...HEAD
+
+-
+
+## [0.3.0][] - 2025-01-08
+
+[0.3.0]: https://github.com/trussed-dev/trussed-staging/releases/tag/hkdf-v0.3.0
 
 - Replace `trussed` dependency with `trussed-core`.
 

--- a/extensions/hkdf/Cargo.toml
+++ b/extensions/hkdf/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "trussed-hkdf"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/extensions/hpke/CHANGELOG.md
+++ b/extensions/hpke/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/hpke-v0.1.0...HEAD
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/hpke-v0.2.0...HEAD
+
+-
+
+## [0.2.0][] - 2025-01-08
+
+[0.2.0]: https://github.com/Nitrokey/trussed-staging/releases/tag/hpke-v0.2.0
 
 - Replace `trussed` dependency with `trussed-core`.
 

--- a/extensions/hpke/Cargo.toml
+++ b/extensions/hpke/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "trussed-hpke"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/extensions/manage/CHANGELOG.md
+++ b/extensions/manage/CHANGELOG.md
@@ -11,9 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
-- Replace `trussed` dependency with `trussed-core`.
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/manage-v0.2.0...HEAD
 
-[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/manage-v0.1.0...HEAD
+-
+
+## [0.2.0][] - 2025-01-08
+
+[0.2.0]: https://github.com/trussed-dev/trussed-staging/releases/tag/manage-v0.2.0
+
+- Replace `trussed` dependency with `trussed-core`.
 
 ## [0.1.0][] - 2024-03-15
 

--- a/extensions/manage/Cargo.toml
+++ b/extensions/manage/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "trussed-manage"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/extensions/wrap-key-to-file/CHANGELOG.md
+++ b/extensions/wrap-key-to-file/CHANGELOG.md
@@ -11,9 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
-- Replace `trussed` dependency with `trussed-core`.
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/wrap-key-to-file-v0.2.0...HEAD
 
-[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/wrap-key-to-file-v0.1.0...HEAD
+-
+
+## [0.2.0][] - 2025-01-08
+
+[0.2.0]: https://github.com/trussed-dev/trussed-staging/releases/tag/wrap-key-to-file-v0.2.0
+
+- Replace `trussed` dependency with `trussed-core`.
 
 ## [0.1.0][] - 2024-03-15
 

--- a/extensions/wrap-key-to-file/Cargo.toml
+++ b/extensions/wrap-key-to-file/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "trussed-wrap-key-to-file"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
This patch releases:
- trussed-chunked v0.2.0
- trussed-hkdf v0.3.0
- trussed-hpke v0.2.0
- trussed-manage v0.2.0
- trussed-wrap-key-to-file v0.2.0
- trussed-fs-info v0.2.0