### PR TITLE
Release extensions and backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/v0.4.0...HEAD
 
+-
+
+## [0.4.0][] - 2026-03-23
+
+[0.4.0]: https://github.com/trussed-dev/trussed-staging/compare/v0.3.3...v0.4.0
+
+- Update extensions:
+  - `trussed-chunked` v0.3.0
+  - `trussed-fs-info` v0.3.0
+  - `trussed-hkdf` v0.4.0
+  - `trussed-hpke` v0.3.0
+  - `trussed-manage` v0.3.0
+  - `trussed-wrap-key-to-file` v0.3.0
 - Update dependencies:
   - `heapless` v0.9
   - `heapless-bytes` v0.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ trussed-core = { version = "0.2", features = ["serde-extensions"] }
 
 [package]
 name = "trussed-staging"
-version = "0.3.3"
+version = "0.4.0"
 description = "Work in progress trussed features"
 authors.workspace = true
 edition.workspace = true
@@ -48,12 +48,12 @@ digest = { version = "0.10.7", default-features = false }
 hex-literal = { version = "0.4.0", optional = true }
 aead = { version = "0.5.2", optional = true, default-features = false }
 
-trussed-chunked = { version = "0.2.0", optional = true }
-trussed-hkdf = { version = "0.3.0", optional = true }
-trussed-hpke = { version = "0.2.0", optional = true }
-trussed-manage = { version = "0.2.1", optional = true }
-trussed-wrap-key-to-file = { version = "0.2.0", optional = true }
-trussed-fs-info = { version = "0.2.0", optional = true } 
+trussed-chunked = { version = "0.3.0", optional = true }
+trussed-hkdf = { version = "0.4.0", optional = true }
+trussed-hpke = { version = "0.3.0", optional = true }
+trussed-manage = { version = "0.3.0", optional = true }
+trussed-wrap-key-to-file = { version = "0.3.0", optional = true }
+trussed-fs-info = { version = "0.3.0", optional = true } 
 heapless = { version = "0.9.1", optional = true }
 heapless-bytes = { version = "0.5.0", optional = true }
 

--- a/extensions/chunked/CHANGELOG.md
+++ b/extensions/chunked/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/chunked-v0.2.0...HEAD
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/chunked-v0.3.0...HEAD
+
+-
+
+## [0.3.0][] - 2026-03-23
+
+[0.3.0]: https://github.com/trussed-dev/trussed-staging/releases/tag/chunked-v0.3.0
 
 - Update to `trussed-core` v0.2
 

--- a/extensions/chunked/Cargo.toml
+++ b/extensions/chunked/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "trussed-chunked"
-version = "0.2.0"
+version = "0.3.0"
 description = "extension with chunked file operations for trussed"
 authors.workspace = true
 edition.workspace = true

--- a/extensions/fs-info/CHANGELOG.md
+++ b/extensions/fs-info/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/fs-info-v0.2.0...HEAD
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/fs-info-v0.3.0...HEAD
+
+-
+
+## [0.3.0][] - 2026-03-23
+
+[0.3.0]: https://github.com/Nitrokey/trussed-staging/releases/tag/fs-info-v0.3.0
 
 - Update to `trussed-core` v0.2
 

--- a/extensions/fs-info/Cargo.toml
+++ b/extensions/fs-info/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "trussed-fs-info"
-version = "0.2.0"
+version = "0.3.0"
 description = "extension providing filesystem metadata for trussed"
 authors.workspace = true
 edition.workspace = true

--- a/extensions/hkdf/CHANGELOG.md
+++ b/extensions/hkdf/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/hkdf-v0.3.0...HEAD
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/hkdf-v0.4.0...HEAD
+
+-
+
+## [0.4.0][] - 2026-03-23
+
+[0.4.0]: https://github.com/trussed-dev/trussed-staging/releases/tag/hkdf-v0.4.0
 
 - Update to `trussed-core` v0.2
 

--- a/extensions/hkdf/Cargo.toml
+++ b/extensions/hkdf/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "trussed-hkdf"
-version = "0.3.0"
+version = "0.4.0"
 description = "HKDF extension for trussed"
 authors.workspace = true
 edition.workspace = true

--- a/extensions/hpke/CHANGELOG.md
+++ b/extensions/hpke/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/hpke-v0.2.0...HEAD
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/hpke-v0.3.0...HEAD
+
+-
+
+## [0.3.0][] - 2026-03-23
+
+[0.3.0]: https://github.com/Nitrokey/trussed-staging/releases/tag/hpke-v0.3.0
 
 - Update to `trussed-core` v0.2
 

--- a/extensions/hpke/Cargo.toml
+++ b/extensions/hpke/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "trussed-hpke"
-version = "0.2.0"
+version = "0.3.0"
 description = "HPKE extension for trussed"
 authors.workspace = true
 edition.workspace = true

--- a/extensions/manage/CHANGELOG.md
+++ b/extensions/manage/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/manage-v0.2.1...HEAD
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/manage-v0.3.0...HEAD
+
+-
+
+## [0.3.0][] - 2026-03-23
+
+[0.3.0]: https://github.com/trussed-dev/trussed-staging/releases/tag/manage-v0.3.0
 
 - Update to `trussed-core` v0.2
 
@@ -20,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.1]: https://github.com/trussed-dev/trussed-staging/releases/tag/manage-v0.2.1
 
 - When factory-resetting, mark empty filesystems for reformatting ([#36](https://github.com/trussed-dev/trussed-staging/pull/36))
-
 
 ## [0.2.0][] - 2025-01-08
 

--- a/extensions/manage/Cargo.toml
+++ b/extensions/manage/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "trussed-manage"
-version = "0.2.1"
+version = "0.3.0"
 description = "management extension for trussed"
 authors.workspace = true
 edition.workspace = true

--- a/extensions/wrap-key-to-file/CHANGELOG.md
+++ b/extensions/wrap-key-to-file/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/wrap-key-to-file-v0.2.0...HEAD
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/wrap-key-to-file-v0.3.0...HEAD
+
+-
+
+## [0.3.0][] - 2026-03-23
+
+[0.3.0]: https://github.com/trussed-dev/trussed-staging/releases/tag/wrap-key-to-file-v0.3.0
 
 - Update to `trussed-core` v0.2
 

--- a/extensions/wrap-key-to-file/Cargo.toml
+++ b/extensions/wrap-key-to-file/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "trussed-wrap-key-to-file"
-version = "0.2.0"
+version = "0.3.0"
 description = "extension for wrapping large keys to the filesystem with trussed"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This patch releases trussed-staging v0.4.0 and the following extension versions:
- trussed-chunked v0.3.0
- trussed-fs-info v0.3.0
- trussed-hkdf v0.4.0
- trussed-hpke v0.3.0
- trussed-manage v0.3.0
- trussed-wrap-key-to-file v0.3.0